### PR TITLE
fix: install does not pull correct Version and URL for Release

### DIFF
--- a/install
+++ b/install
@@ -14,11 +14,9 @@ COLOR_NORMAL="\033[39m"
 
 GITHUB_URL="https://api.github.com/repos/bromanko/dot-slash-go/releases/latest"
 RELEASE_VERSION=`curl --silent ${GITHUB_URL} \
-  | grep '"tag_name":' \
-  | sed -E 's/.*"([^"]+)".*/\1/'`
+  | sed -E 's/.*"tag_name":"([^"]+)".*/\1/'`
 RELEASE_URL=`curl --silent ${GITHUB_URL} \
-  | grep '"browser_download_url":' \
-  | sed -E 's/.*"([^"]+)".*/\1/'`
+  | sed -E 's/.*"browser_download_url":"([^"]+)".*/\1/'`
 
 echo -e "${COLOR_BLUE}Installing dot-slash-go ${RELEASE_VERSION}${COLOR_NORMAL}"
 echo -e "${COLOR_DARK_GRAY}${RELEASE_URL}${COLOR_NORMAL}"


### PR DESCRIPTION
### Issue

The install bash script does not grab the Version and Url from the latest release correctly. The grep was highlighting the correct json key but the value was always body which was not able to download that release thus the install would silently fail.

<img width="712" alt="screen shot 2017-10-22 at 10 54 47 pm" src="https://user-images.githubusercontent.com/996560/31870522-7290b106-b77c-11e7-9585-817fee06f730.png">

### Solution

Simplified the sed to do all of the work

### Disclosure

I suck at sed so this might not be the best solution but I found it "works on my machine".
